### PR TITLE
Duplicate explicit target name fix

### DIFF
--- a/pages/events.rst
+++ b/pages/events.rst
@@ -42,13 +42,13 @@ Februar 2018
 März 2018
 ---------
 * 2018-03-20T19:00:00+01:00: `Chaos. Communication. Caffeine. <https://metalab.at/wiki/CCC_Wien>`_, `Metalab Wien <https://metalab.at>`_
-* 2018-03-30/2018-04-02: `Easterhegg <https://eh18.easterhegg.eu/>`_, Würzburg
+* 2018-03-30/2018-04-02: `Easterhegg 18 <https://eh18.easterhegg.eu/>`_, Würzburg
 
 April 2018
 ----------
 * 2018-04-17T19:00:00+01:00: `Chaos. Communication. Caffeine. <https://metalab.at/wiki/CCC_Wien>`_, `Metalab Wien <https://metalab.at>`_
-* 2018-04-20/2018-04-21: `Linuxwochen Eisenstadt <https://www.linuxwochen.at/>`_, tbd, Eisenstadt
-* 2018-04-27/2018-04-28: `Linuxtage Graz <https://linuxtage.at/>`_, tbd, Graz
+* 2018-04-20/2018-04-21: `Linuxwochen Eisenstadt 2018 <https://www.linuxwochen.at/>`_, tbd, Eisenstadt
+* 2018-04-27/2018-04-28: `Linuxtage Graz 2018 <https://linuxtage.at/>`_, tbd, Graz
 
 Mai 2018
 --------


### PR DESCRIPTION
System Message: WARNING/2 (<string>, line 72); backlink
Duplicate explicit target name: "easterhegg".

System Message: WARNING/2 (<string>, line 72); backlink
Duplicate explicit target name: "linuxwochen eisenstadt".

@oe1rfc FYI 